### PR TITLE
Fix contributors workflow to use GH_PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -19,13 +19,8 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.GH_PAT }}
-      uses: actions/checkout@v4
-      with:
-        ref: main
-        token: ${{ secrets.GH_PAT }}
->>>>>>> b332b8b411101a8d4324da5d6f6d73fa9b64cf82
 
-    - name: Get PR author info
+      - name: Get PR author info
       id: pr-author
       run: |
         AUTHOR_LOGIN="${{ github.event.pull_request.user.login }}"
@@ -38,52 +33,52 @@ jobs:
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
-    - name: Check if contributor already exists in list
-      id: check-contributor
-      run: |
-        AUTHOR_LOGIN="${{ steps.pr-author.outputs.author_login }}"
-        if [ ! -f "docs/CONTRIBUTORS.md" ]; then
-          echo "Contributors file does not exist, will create it"
-          mkdir -p docs
-          echo "# Contributors" > docs/CONTRIBUTORS.md
-          echo "" >> docs/CONTRIBUTORS.md
-          echo "This file lists all the contributors to this project." >> docs/CONTRIBUTORS.md
-          echo "" >> docs/CONTRIBUTORS.md
-          echo "## List of Contributors" >> docs/CONTRIBUTORS.md
-          echo "" >> docs/CONTRIBUTORS.md
-          echo "contributor_exists=false" >> $GITHUB_OUTPUT
-        elif grep -q "\[$AUTHOR_LOGIN\](https://github.com/$AUTHOR_LOGIN)" docs/CONTRIBUTORS.md; then
-          echo "contributor_exists=true" >> $GITHUB_OUTPUT
-          echo "Contributor $AUTHOR_LOGIN already exists in the list"
-        else
-          echo "contributor_exists=false" >> $GITHUB_OUTPUT
-          echo "Contributor $AUTHOR_LOGIN does not exist in the list"
-        fi
+        - name: Check if contributor already exists in list
+        id: check-contributor
+          run: |
+          AUTHOR_LOGIN="${{ steps.pr-author.outputs.author_login }}"
+            if [ ! -f "docs/CONTRIBUTORS.md" ]; then
+            echo "Contributors file does not exist, will create it"
+            mkdir -p docs
+            echo "# Contributors" > docs/CONTRIBUTORS.md
+            echo "" >> docs/CONTRIBUTORS.md
+            echo "This file lists all the contributors to this project." >> docs/CONTRIBUTORS.md
+            echo "" >> docs/CONTRIBUTORS.md
+            echo "## List of Contributors" >> docs/CONTRIBUTORS.md
+            echo "" >> docs/CONTRIBUTORS.md
+            echo "contributor_exists=false" >> $GITHUB_OUTPUT
+            elif grep -q "\[$AUTHOR_LOGIN\](https://github.com/$AUTHOR_LOGIN)" docs/CONTRIBUTORS.md; then
+            echo "contributor_exists=true" >> $GITHUB_OUTPUT
+            echo "Contributor $AUTHOR_LOGIN already exists in the list"
+            else
+            echo "contributor_exists=false" >> $GITHUB_OUTPUT
+            echo "Contributor $AUTHOR_LOGIN does not exist in the list"
+                fi
 
-    - name: Add contributor to list
-      if: steps.check-contributor.outputs.contributor_exists == 'false'
-      run: |
-        AUTHOR_LOGIN="${{ steps.pr-author.outputs.author_login }}"
-        AUTHOR_URL="${{ steps.pr-author.outputs.author_url }}"
-        PR_NUMBER="${{ steps.pr-author.outputs.pr_number }}"
-        PR_URL="${{ steps.pr-author.outputs.pr_url }}"
-        
-        # Create the entry format as per existing style
-        NEW_ENTRY="($AUTHOR_LOGIN)\[$AUTHOR_URL\] in PR (#$PR_NUMBER)\[$PR_URL\]"
-        
-        # Add new entry to the file, preserving existing content
-        echo "" >> docs/CONTRIBUTORS.md  # Add a blank line for separation
-        echo "$NEW_ENTRY" >> docs/CONTRIBUTORS.md
+      - name: Add contributor to list
+        if: steps.check-contributor.outputs.contributor_exists == 'false'
+        run: |
+          AUTHOR_LOGIN="${{ steps.pr-author.outputs.author_login }}"
+          AUTHOR_URL="${{ steps.pr-author.outputs.author_url }}"
+          PR_NUMBER="${{ steps.pr-author.outputs.pr_number }}"
+          PR_URL="${{ steps.pr-author.outputs.pr_url }}"
 
-    - name: Create Pull Request for contributor update
-      if: steps.check-contributor.outputs.contributor_exists == 'false'
-      uses: peter-evans/create-pull-request@v6
-      with:
-        token: ${{ secrets.GH_PAT }}
-        commit-message: "Add ${{ steps.pr-author.outputs.author_login }} to contributors list"
-        title: "Add ${{ steps.pr-author.outputs.author_login }} to contributors"
-        body: "Automated PR to add ${{ steps.pr-author.outputs.author_login }} to the contributors list for PR #${{ steps.pr-author.outputs.pr_number }}"
-        branch: add-contributor-${{ steps.pr-author.outputs.author_login }}
-        base: main
-        add-paths: |
-          docs/CONTRIBUTORS.md
+          # Create the entry format as per existing style
+          NEW_ENTRY="($AUTHOR_LOGIN)\[$AUTHOR_URL\] in PR (#$PR_NUMBER)\[$PR_URL\]"
+
+          # Add new entry to the file, preserving existing content
+          echo "" >> docs/CONTRIBUTORS.md  # Add a blank line for separation
+          echo "$NEW_ENTRY" >> docs/CONTRIBUTORS.md
+
+            - name: Create Pull Request for contributor update
+            if: steps.check-contributor.outputs.contributor_exists == 'false'
+            uses: peter-evans/create-pull-request@v6
+            with:
+              token: ${{ secrets.GH_PAT }}
+              commit-message: "Add ${{ steps.pr-author.outputs.author_login }} to contributors list"
+              title: "Add ${{ steps.pr-author.outputs.author_login }} to contributors"
+              body: "Automated PR to add ${{ steps.pr-author.outputs.author_login }} to the contributors list for PR #${{ steps.pr-author.outputs.pr_number }}"
+              branch: add-contributor-${{ steps.pr-author.outputs.author_login }}
+              base: main
+              add-paths: |
+                docs/CONTRIBUTORS.md


### PR DESCRIPTION
- Replace GITHUB_TOKEN with GH_PAT in checkout and PR creation steps
- Add GH_TOKEN environment variable for GitHub CLI compatibility
- This resolves permission issues for creating pull requests

Amp-Thread-ID: https://ampcode.com/threads/T-c840ae4c-9ab0-4105-9aad-39630656fec0

Be sure to create a PAT with the following scopes:

repo
workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated contributor workflow to add a new authentication environment variable and align token usage across steps.
  * Switched checkout and pull-request creation steps to use the new token source.
  * Removed duplicated checkout step and adjusted step ordering.
  * Minor formatting and indentation improvements in the workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->