### PR TITLE
Add STATS_KEY environment variable for secure stats hashing

### DIFF
--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -1407,6 +1407,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
           'error_type': 'missing_config',
         },
       );
+        if (context.mounted) {
+          showTopSnackBar(
+            context,
+            'Fout: Exportconfiguratie voor statistieken ontbreekt. Neem contact op met support.',
+            style: TopSnackBarStyle.error,
+          );
+        }
+        return;
     }
 
     try {


### PR DESCRIPTION
Exported stats were quite easily editable by reverse engineering the encoding process.
Now, if you add the 'STATS_KEY' environment variable, that will be included for hashing, so the user cannot generate the correct hash (since he doesn't know the environment variable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Export/import now use a configured keyed HMAC for salted integrity checks instead of plain hashes.
  * Import accepts both legacy and new formats and verifies integrity consistently, with clearer failure messages.
  * Pre-flight validation now surfaces a storage/configuration error and aborts export/import when the required key is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->